### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-postgres-container/pom.xml
+++ b/worker-postgres-container/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-postgres-container</artifactId>
+    <name>worker-postgres-container</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/worker-postgres/pom.xml
+++ b/worker-postgres/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-postgres</artifactId>
+    <name>worker-postgres</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210